### PR TITLE
Fix Hacker Hours website link

### DIFF
--- a/ruby-focused/README.md
+++ b/ruby-focused/README.md
@@ -68,7 +68,7 @@ http://www.meetup.com/hackerhours/events/230225164/
 
 * Standup
 * Thanks
-* We'll do more of these workshops, and meanwhile, come to [Hacker Hours](www.meetup.com/hackerhours) and [Ruby Project Night](http://www.meetup.com/Ruby-Project-Night-NYC) meetups!
+* We'll do more of these workshops, and meanwhile, come to [Hacker Hours](http://www.meetup.com/hackerhours) and [Ruby Project Night](http://www.meetup.com/Ruby-Project-Night-NYC) meetups!
 
 ## Guidelines
 


### PR DESCRIPTION
With the 'http://' it used the current directory as a relative link
